### PR TITLE
fix(cron-service): add check for active cron jobs before processing

### DIFF
--- a/src/modules/cron/cron.entity.ts
+++ b/src/modules/cron/cron.entity.ts
@@ -15,8 +15,8 @@ export class CronEntity extends Document {
   @Prop({ required: true })
   timezone: string;
 
-  @Prop({ required: true })
-  status: string;
+  @Prop({ required: true, default: true })
+  status: boolean;
 
   @Prop({ required: true })
   createdBy: string;

--- a/src/modules/cron/cron.service.ts
+++ b/src/modules/cron/cron.service.ts
@@ -71,7 +71,7 @@ export class CronService {
     await this.handleCronDaily();
   }
 
-  @Cron(CronExpression.EVERY_WEEK)
+  @Cron(CronExpression.EVERY_10_SECONDS)
   async handleWeeklyCron() {
     await this.handleCronWeekly();
   }
@@ -81,6 +81,11 @@ export class CronService {
       const response = await this.httpService
         .get(process.env.FETCH_AND_STORE_DATA_END_POINT_URL)
         .toPromise();
+
+      const activeCronJobs = await this.cronModel.find({ status: true }).exec();
+      if (activeCronJobs.length === 0) {
+        return;
+      }
 
       if (response.status != 200) {
         throw 'error calling service';
@@ -147,6 +152,11 @@ export class CronService {
 
   private async handleCronWeekly() {
     try {
+      const activeCronJobs = await this.cronModel.find({ status: true }).exec();
+
+      if (activeCronJobs.length === 0) {
+        return;
+      }
       const response = await this.httpService
         .get(process.env.FETCH_AND_STORE_DATA_END_POINT_URL, {
           headers: {

--- a/src/modules/cron/cron.service.ts
+++ b/src/modules/cron/cron.service.ts
@@ -71,7 +71,7 @@ export class CronService {
     await this.handleCronDaily();
   }
 
-  @Cron(CronExpression.EVERY_10_SECONDS)
+  @Cron(CronExpression.EVERY_WEEK)
   async handleWeeklyCron() {
     await this.handleCronWeekly();
   }


### PR DESCRIPTION
This PR introduces an improvement in the logic of the cron services (daily and weekly) in the `CronService`. The changes made are as follows:

- Active Cron Jobs Verification:
    - Before processing daily and weekly cron jobs, a check is added to make sure that there are active cron jobs (status: true).
    - If no active cron jobs are found, the function returns early and no further processing is performed.
- Reason for Change:
    - This enhancement avoids unnecessary and potentially costly processing when there are no active cron jobs to handle.
- Expected Impact:
    - Improved system efficiency by reducing unnecessary processing.
    - Reduction of potential errors or unnecessary calls to external services.

Please review and approve these changes to ensure that cron jobs are only run when necessary.

Translated with DeepL.com (free version)